### PR TITLE
[BUG] Fix m_separated to work on only bidirected edge graph

### DIFF
--- a/pywhy_graphs/networkx/algorithms/causal/tests/test_m_separation.py
+++ b/pywhy_graphs/networkx/algorithms/causal/tests/test_m_separation.py
@@ -43,3 +43,10 @@ def test_m_separation():
 
     # conditioning on a descendant of a collider via bidirected edge opens the collider
     assert not pywhy_nx.m_separated(G, {0}, {3}, {4})
+
+
+def test_m_separation_bidirected_graph():
+    # a bidirected graph should be m-separated without conditioning on anything
+    bigraph = nx.Graph([(1, 2), (2, 3)])
+    G = pywhy_nx.MixedEdgeGraph([bigraph], ["bidirected"])
+    assert pywhy_nx.m_separated(G, {1}, {3}, set())


### PR DESCRIPTION
Fixes #44 

cc: @jaron-lee can you lmk if this works alright for you? I presume you need to extend this fix to also undirected edges?

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/py-why/pywhy-graphs/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
